### PR TITLE
NEW option to auto fill event title with type

### DIFF
--- a/admin/fullcalendar_setup.php
+++ b/admin/fullcalendar_setup.php
@@ -116,6 +116,19 @@ print '<td align="center" width="100">'.$langs->trans("Value").'</td>'."\n";
 // Example with a yes / no select
 $var=!$var;
 print '<tr '.$bc[$var].'>';
+print '<td>'.$langs->trans("FULLCALENDAR_AUTO_FILL_TITLE").'</td>';
+print '<td align="center" width="20">&nbsp;</td>';
+print '<td align="right" width="300">';
+print '<form method="POST" action="'.$_SERVER['PHP_SELF'].'">';
+print '<input type="hidden" name="token" value="'.$_SESSION['newtoken'].'">';
+print '<input type="hidden" name="action" value="set_FULLCALENDAR_AUTO_FILL_TITLE">';
+echo ajax_constantonoff('FULLCALENDAR_AUTO_FILL_TITLE');
+print '</form>';
+print '</td></tr>';
+
+// Example with a yes / no select
+$var=!$var;
+print '<tr '.$bc[$var].'>';
 print '<td>'.$langs->trans("FULLCALENDAR_SHOW_AFFECTED_USER").'</td>';
 print '<td align="center" width="20">&nbsp;</td>';
 print '<td align="right" width="300">';

--- a/js/fullcalendar.js.php
+++ b/js/fullcalendar.js.php
@@ -135,6 +135,21 @@ if(empty($refer) || preg_match('/comm\/action\/index.php/', $refer))
 
 	$(document).ready(function() {
 
+
+
+        <?php if (!empty($conf->global->FULLCALENDAR_AUTO_FILL_TITLE)) { ?>
+        $(document).on("change", "#pop-new-event #type_code", function() {
+            var typeCodeTitle = $( "#type_code option:selected" ).text();
+
+            var labelContent =$( "#pop-new-event input[name='label']" ).val();
+            if(!labelContent.length){
+                $( "#pop-new-event input[name='label']" ).val(typeCodeTitle);
+            }
+        });
+        <?php } ?>
+
+
+
 		$('.wordbreak').hide(); //hide std dolibarr btn to change date
 
 		<?php if (!empty($conf->global->FULLCALENDAR_FILTER_ON_STATE)) { ?>

--- a/langs/fr_FR/fullcalendar.lang
+++ b/langs/fr_FR/fullcalendar.lang
@@ -27,6 +27,7 @@ FULLCALENDAR_PREFILL_DATETIME_MORNING_START=Début de la plage du matin
 FULLCALENDAR_PREFILL_DATETIME_MORNING_END=Fin de la page du matin
 FULLCALENDAR_PREFILL_DATETIME_AFTERNOON_START=Début de la page de l'après-midi
 FULLCALENDAR_PREFILL_DATETIME_AFTERNOON_END=Fin de la page de l'après-midi
+FULLCALENDAR_AUTO_FILL_TITLE=Pré-remplissage du champ titre si vide lors de la sélection du type de l’événement
 
 EditAnAction=Éditer un événement
 NoRightsToEdit=Vous n'avez pas le droit d'édition


### PR DESCRIPTION
TK9267

Ajout de la fonctionnalité dans fullcalendar : pré-remplissage du champ titre si vide lors de la sélection du type de l’événement 