### PR TITLE
FIX: no events displayed when using postgre sql

### DIFF
--- a/core/modules/modfullcalendar.class.php
+++ b/core/modules/modfullcalendar.class.php
@@ -105,7 +105,7 @@ class modfullcalendar extends DolibarrModules
 
 		// Dependencies
 		$this->hidden = false;			// A condition to hide module
-		$this->depends = array();		// List of modules id that must be enabled if this module is enabled
+		$this->depends = array('modAgenda');		// List of modules id that must be enabled if this module is enabled
 		$this->requiredby = array();	// List of modules id to disable if this one is disabled
 		$this->conflictwith = array();	// List of modules id this module is in conflict with
 		$this->phpmin = array(5,0);					// Minimum version of PHP required by module

--- a/js/fullcalendar.js.php
+++ b/js/fullcalendar.js.php
@@ -1,4 +1,5 @@
 <?php
+header('Content-Type: text/javascript');
 $refer = '';
 if(isset($_SERVER['HTTP_REFERER'])) $refer = $_SERVER['HTTP_REFERER'];
 

--- a/script/interface.php
+++ b/script/interface.php
@@ -39,9 +39,8 @@
 			}
 	*/
 			$TEvent = _events($start, $end);
+			foreach ($TEvent as &$event) unset($event['object']->db);
 			__out($TEvent, 'json');
-
-
 			break;
 		default:
 


### PR DESCRIPTION
`json_encode()` fails silently in an ajax call because the object to be serialized contains a db object. Apparently, MySQL db connections can be serialized but not PostgreSQL ones.

+ 2 minor fixes (browser warning + module dependency)