### PR TITLE
FIX: Trigger class doesn't extend DolibarrTriggers

### DIFF
--- a/core/triggers/interface_99_modfullcalendar_fullcalendartrigger.class.php
+++ b/core/triggers/interface_99_modfullcalendar_fullcalendartrigger.class.php
@@ -33,11 +33,8 @@
 /**
  * Trigger class
  */
-class Interfacefullcalendartrigger
+class Interfacefullcalendartrigger extends DolibarrTriggers
 {
-
-    private $db;
-
     /**
      * Constructor
      *
@@ -101,7 +98,7 @@ class Interfacefullcalendartrigger
 
     /**
      * Function called when a Dolibarrr business event is done.
-     * All functions "run_trigger" are triggered if file
+     * All functions "runTrigger" are triggered if file
      * is inside directory core/triggers
      *
      * 	@param		string		$action		Event action code
@@ -111,7 +108,7 @@ class Interfacefullcalendartrigger
      * 	@param		conf		$conf		Object conf
      * 	@return		int						<0 if KO, 0 if no triggered ran, >0 if OK
      */
-    public function run_trigger($action, $object, $user, $langs, $conf)
+    public function runTrigger($action, $object, $user, $langs, $conf)
     {
         // Put here code you want to execute when a Dolibarr business events occurs.
         // Data and type of action are stored into $object and $action


### PR DESCRIPTION
# FIX
- Change the subtotal module trigger class definition to avoid error message from Dolibarr
- Rename `run_trigger` to `runTrigger`
- Remove the declaration of the `$db` field if present (already declared as `protected` in the parent class)
