### PR TITLE
FIX | DA023055 : cas non applicable

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 
 ## Version 2.5
-
+- FIX : DA023055 - Gestion de la recherche sur le statut "Non applicable" *07/03/2023* 2.5.3
 - FIX : Remove deprecated function call *03/08/2022* 2.5.2
 - FIX : Icon for v16 compatibility *03/08/2022* 2.5.1
 - NEW : Ajout de la class TechATM pour l'affichage de la page "A propos" *11/05/2022* 2.5.0

--- a/core/modules/modfullcalendar.class.php
+++ b/core/modules/modfullcalendar.class.php
@@ -61,7 +61,7 @@ class modfullcalendar extends DolibarrModules
 		$this->description = "Description of module fullcalendar";
 		// Possible values for version are: 'development', 'experimental', 'dolibarr' or version
 
-		$this->version = '2.5.1';
+		$this->version = '2.5.3';
 		// Url to the file with your last numberversion of this module
 		require_once __DIR__ . '/../../class/techatm.class.php';
 		$this->url_last_version = \fullcalendar\TechATM::getLastModuleVersionUrl($this);

--- a/script/interface.php
+++ b/script/interface.php
@@ -592,7 +592,7 @@ function _events($date_start, $date_end) {
 
 	if ($type) $sql.= " AND ca.id = ".$type;
 	if ($status == '0') { $sql.= " AND a.percent = 0"; }
-	if ($status == '-1') { $sql.= " AND a.percent = -1"; }	// Not applicable
+	if ($status == 'na') { $sql.= " AND a.percent = -1"; }	// Not applicable
 	if ($status == '50') { $sql.= " AND (a.percent > 0 AND a.percent < 100)"; }	// Running already started
 	if ($status == 'done' || $status == '100') { $sql.= " AND (a.percent = 100 OR (a.percent = -1 AND a.datep2 <= '".$db->idate($now)."'))"; }
 	if ($status == 'todo') { $sql.= " AND ((a.percent >= 0 AND a.percent < 100) OR (a.percent = -1 AND a.datep2 > '".$db->idate($now)."'))"; }


### PR DESCRIPTION
## FIX | DA023055 : cas non applicable : 

Pour la recherche sur statut (vue calendrier) : 
La valeur du statut "Non-applicable" est "na" 
Ainsi, c'est dans le cas "na" que la requête doit comporter une condition sur le pourcentage à -1 car cela correspond au statut "Non-applicable"

