### PR TITLE
Add LIMIT on query to fetch events

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 
 ## Release 2.6
+- FIX : Add LIMIT on query to fetch events, to prevent memory limit access - DA024924 - *30/05/2024* - 2.6.8
 - FIX : Fuseau UTC php add event retour ticket- *17/05/2024* - 2.6.7
 - FIX : No fullcalendar on calendar view (because of http_referer) - *29/04/2024* - 2.6.6 
 - FIX : Warnings bloquant l'activation du module - *10/04/2024* - 2.6.5

--- a/core/modules/modfullcalendar.class.php
+++ b/core/modules/modfullcalendar.class.php
@@ -61,7 +61,7 @@ class modfullcalendar extends DolibarrModules
 		$this->description = "Description of module fullcalendar";
 		// Possible values for version are: 'development', 'experimental', 'dolibarr' or version
 
-		$this->version = '2.6.7';
+		$this->version = '2.6.8';
 		// Url to the file with your last numberversion of this module
 		require_once __DIR__ . '/../../class/techatm.class.php';
 		$this->url_last_version = \fullcalendar\TechATM::getLastModuleVersionUrl($this);

--- a/script/interface.php
+++ b/script/interface.php
@@ -611,7 +611,7 @@ function _events($date_start, $date_end) {
 	}
 	// Sort on date
 	$sql.= ' ORDER BY datep';
-
+	$sql .= " LIMIT 100";
 
 	$TEvent=array();
 	if(isset($_REQUEST['DEBUG'])) print $sql;


### PR DESCRIPTION
This is a temporary fix, while waiting for a real optimization (currently doing too much queries per event)