### PR TITLE
FIX - SUPPORT - DA026711 - Warnings console

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 ## Not Released
 
 ## Release 2.7
+- FIX: DA026711 - removed a str_replace that was causing an error in the console because line breaks were being removed for no reason and a comment in the std lib was causing a problem - *30/07/2025* - 2.7.16
 - FIX: DA026711 infinite loop call stack in cloning event - *25/06/2025* - 2.7.15
 - FIX: DA026440 incorrect end date for all-day event - *22/05/2025* - 2.7.14
 - FIX: Update leave handling with half-day precision - *20/05/2025* - 2.7.13

--- a/core/modules/modfullcalendar.class.php
+++ b/core/modules/modfullcalendar.class.php
@@ -61,7 +61,7 @@ class modfullcalendar extends DolibarrModules
 		$this->description = "Description of module fullcalendar";
 		// Possible values for version are: 'development', 'experimental', 'dolibarr' or version
 
-		$this->version = '2.7.15';
+		$this->version = '2.7.16';
 		// Url to the file with your last numberversion of this module
 		require_once __DIR__ . '/../../class/techatm.class.php';
 		$this->url_last_version = \fullcalendar\TechATM::getLastModuleVersionUrl($this);

--- a/js/fullcalendar.js.php
+++ b/js/fullcalendar.js.php
@@ -795,7 +795,6 @@ header('Content-Type: text/javascript');
 				$TRemindTypes = array();
 				if (getDolGlobalString('AGENDA_REMINDER_EMAIL')) $TRemindTypes['email'] = $langs->trans('EMail');
 				if (getDolGlobalString('AGENDA_REMINDER_BROWSER')) $TRemindTypes['browser'] = $langs->trans('BrowserPush');
-				$select_remindertype =  str_replace("\n", '', $form->selectarray('selectremindertype', $TRemindTypes));
 				$select_remindertype =  $form->selectarray('selectremindertype', $TRemindTypes);
 
 				if (is_callable(array($form, 'selectModelMail'), true)) {

--- a/js/fullcalendar.js.php
+++ b/js/fullcalendar.js.php
@@ -796,6 +796,7 @@ header('Content-Type: text/javascript');
 				if (getDolGlobalString('AGENDA_REMINDER_EMAIL')) $TRemindTypes['email'] = $langs->trans('EMail');
 				if (getDolGlobalString('AGENDA_REMINDER_BROWSER')) $TRemindTypes['browser'] = $langs->trans('BrowserPush');
 				$select_remindertype =  str_replace("\n", '', $form->selectarray('selectremindertype', $TRemindTypes));
+				$select_remindertype =  $form->selectarray('selectremindertype', $TRemindTypes);
 
 				if (is_callable(array($form, 'selectModelMail'), true)) {
 					$select_mailtemplate = str_replace("\n", '', $form->selectModelMail('actioncommsend', 'actioncomm_send', 1));


### PR DESCRIPTION
Suppression d'un str_replace qui provoquait une erreur dans la console parce que les sauts de ligne étaient supprimés sans raison et qu'un commentaire dans la librairie std causait un problème