### PR TITLE
`fix(fullcalendar): Ensure contact ID is preserved during assignment`

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 ## Not Released
 
 ## Release 2.7
+- FIX: DA027064 - Contact id wasn't kept - *19/09/2025* - 2.7.18
 - FIX: DA026711 - Adding mode = 3 to a dol_escape_js call to avoid js syntax error due to wrong string delimiters - *01/08/2025* - 2.7.17
 - FIX: COMPAT V22 - *31/07/2025* - 2.7.16 
 - FIX: DA026711 - removed a str_replace that was causing an error in the console because line breaks were being removed for no reason and a comment in the std lib was causing a problem - *30/07/2025* - 2.7.16

--- a/core/modules/modfullcalendar.class.php
+++ b/core/modules/modfullcalendar.class.php
@@ -61,7 +61,7 @@ class modfullcalendar extends DolibarrModules
 		$this->description = "Description of module fullcalendar";
 		// Possible values for version are: 'development', 'experimental', 'dolibarr' or version
 
-		$this->version = '2.7.17';
+		$this->version = '2.7.18';
 		// Url to the file with your last numberversion of this module
 		require_once __DIR__ . '/../../class/techatm.class.php';
 		$this->url_last_version = \fullcalendar\TechATM::getLastModuleVersionUrl($this);

--- a/script/interface.php
+++ b/script/interface.php
@@ -291,6 +291,7 @@ if (!defined('NOTOKENRENEWAL')) define('NOTOKENRENEWAL', 1); // Disables token r
 
 			$a->socid = GETPOST('fk_soc', 'int');
 			$a->contact_id = GETPOST('fk_contact', 'int');
+			$a->socpeopleassigned[$a->contact_id] = $a->contact_id;
 
 			$a->fk_project = GETPOST('fk_project','int');
 


### PR DESCRIPTION
- Updated `interface.php` to retain contact ID in `socpeopleassigned`.
- Updated module version to `2.7.18` in `modfullcalendar.class.php`.
- Added changelog entry for the fix.

Closes DA027064.