### PR TITLE
Fix missing events because of invalid month parameter given in month navigation

### DIFF
--- a/js/fullcalendar.js.php
+++ b/js/fullcalendar.js.php
@@ -552,7 +552,7 @@ header('Content-Type: text/javascript');
 				var newDate = new Date(
 					$date.getMonth() == 0 ? $date.getFullYear()-1 : $date.getFullYear()
 					, $date.getMonth() == 0 ? 11 : $date.getMonth()-1
-					, $date.getDate()
+					, 1
 				);
 				console.log('prevMonth', newDate.toDateString())
 			}
@@ -596,7 +596,7 @@ header('Content-Type: text/javascript');
 				var newDate = new Date(
 					$date.getMonth() == 11 ? $date.getFullYear()+1 : $date.getFullYear()
 					, $date.getMonth() == 11 ? 0 : $date.getMonth()+1
-					, $date.getDate()
+					, 1
 				);
 				console.log('nextMonth', newDate.toDateString())
 			}


### PR DESCRIPTION
In month view, when you navigate to next/previous month, the 'month' parameter send to interface.php to get events can be erroneous.
Case of today : 2025/09/29

Concerned code is :
```js
// From fullcalendar.js.php
var $date = new Date($currentYear.val(), $currentMonth.val()-1, $currentDay.val());
...
var newDate = new Date(
	$date.getMonth() == 0 ? $date.getFullYear()-1 : $date.getFullYear()
	, $date.getMonth() == 0 ? 11 : $date.getMonth()-1
	, $date.getDate()
);
```
will give the 2025/03/01 because it uses currentDay number => 2025/02/29 which is converted to 2025/03/01 and request to interface.php will send month = 3
=> then it will return events from march but not those from february

By using first day of the month (instead of day number of today), it returns the good month.